### PR TITLE
Automatic Dockerfile Image Updater

### DIFF
--- a/Docker/build/images/proxy/Dockerfile
+++ b/Docker/build/images/proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM jwilder/nginx-proxy
+FROM jwilder/nginx-proxy:v0.9.0
 MAINTAINER David Dell <parkerdell94@gmail.com>
 
 COPY my_proxy.conf /etc/nginx/conf.d/my_proxy.conf


### PR DESCRIPTION
`jwilder/nginx-proxy` changed recently. This pull request ensures you're using the latest version of the image and changes `jwilder/nginx-proxy` to the latest tag: `v0.9.0`

New base image: `jwilder/nginx-proxy:v0.9.0`